### PR TITLE
Use semantic versioning for the E40P.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # core-v-mcu-devkit
-The CORE-V MCU DevKit is an evaluation platform for the OpenHW RISC-V CV32E40P0 IP.  More information can be found at the [CV32E40P0 repo](https://github.com/openhwgroup/cv32e40p0).
+The CORE-V MCU DevKit is an evaluation platform for the OpenHW RISC-V CV32E40P core IP (v1.0.0).  More information can be found at the [CV32E40P repo](https://github.com/openhwgroup/cv32e40p0).
 
 ## Organization
 
@@ -10,7 +10,7 @@ The CORE-V MCU DevKit is an evaluation platform for the OpenHW RISC-V CV32E40P0 
 ## About the devkit
 
 This devkit has the following features:
-1. CV32E40P0 MCU + Embedded FPGA
+1. CV32E40P (v1.0.0) RISC-V core + Embedded FPGA
 2. 4MB Flash memory to hold programs and EFPGA bit images
 3. Onboard Ashling Opella LD JTAG debugger + Serial Consol interface
 4. Offboard JTAG Connector
@@ -23,18 +23,19 @@ This devkit has the following features:
 11. Espressif AWS IoT ExpressLink interface for cloud learning
 
 ![devkit image](images/OpenHW%20DevKit%20-%20top.png)
-[Schematic](file://OpenHW%20CORE-V%20MCU%20DevKit.pdf)
+
+<!-- [Schematic](file://OpenHW%20CORE-V%20MCU%20DevKit.pdf) -->
 
 ## Power
 The devkit can be powered from 5 - 18V.  This can be easily accomplished via the 2.1mm DC barrel jack.  The USB-C connector will negotiate 5v from the USB source.
 
 ## Voltage levels
-The CV32E40P0 has a 1.8v I/O pad ring.  The 3.3v peripherals are interfaced to the 1.8v CV32E40P0 with 7 level shifters.  The pins directly around the CV32E40P0 are connected directly to the CV32E40P0 pads and will be 1.8v logic.  The QSPI program flash memory is also at 1.8v logic.  The JTAG interface to the Ashling Opella LD is level shifted.  The enable signals on the JTAG level shifters is connected to jumper J4.  Inserting a jumper will disable the level shifters to the on-board JTAG interface allowing the JTAG header to be used.  
+The CORE-V-MCU has a 1.8v I/O pad ring.  The 3.3v peripherals are interfaced to the 1.8v MCU with 7 level shifters.  The pins directly around the MCU are connected directly to the MCU pads and will be 1.8v logic.  The QSPI program flash memory is also at 1.8v logic.  The JTAG interface to the Ashling Opella LD is level shifted.  The enable signals on the JTAG level shifters is connected to jumper J4.  Inserting a jumper will disable the level shifters to the on-board JTAG interface allowing the JTAG header to be used.  
 
 
-> Note: the JTAG header is directly connected to the CV32E40P0 and will require 1.8v logic.
+> Note: the JTAG header is directly connected to the CORE-V-MCU and will require 1.8v logic.
 
 ## mikroBUS
-The microBUS header provides a UART, GPIO, I2C and SPI interface.  The UART interface is shared with the AWS IoT ExpressLink.  The CV32E40P0 has an I/O multiplexer and an alternate pin mode allows the UART interface to be switched between two sets of I/O pins.
+The microBUS header provides a UART, GPIO, I2C and SPI interface.  The UART interface is shared with the AWS IoT ExpressLink.  The CORE-V-MCU has an I/O multiplexer and an alternate pin mode allows the UART interface to be switched between two sets of I/O pins.
 The microBUS is fully wired except for the 5v power option.  5v is not available to microBUS so ensure any CLICK's are configured for 3.3v.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The CORE-V MCU DevKit is an evaluation platform for the OpenHW RISC-V CV32E40P c
 ## About the devkit
 
 This devkit has the following features:
-1. CV32E40P (v1.0.0) RISC-V core + Embedded FPGA
+1. CORE-V MCU (including CV32E40P (v1.0.0) RISC-V core and Quicklogic ArcticPro2 Embedded FPGA)
 2. 4MB Flash memory to hold programs and EFPGA bit images
 3. Onboard Ashling Opella LD JTAG debugger + Serial Consol interface
 4. Offboard JTAG Connector


### PR DESCRIPTION
Hi @DBees.  This PR makes a few edits:
1. All the references to the CV32E40P now use semantic versioning.  That is, `CV32E40P0` is replaced with `CV32E40P (v1.0.0)`.
2. The link to the schematic is broken, so it is commented it out.
3. The text confused the `CV32E40P` with the `CORE-V-MCU`, so these have been corrected.  (For example, the CV32E40P is not directly connected to the I/O PAD ring.)